### PR TITLE
[FEAT] Increase scoring accuracy (#5)

### DIFF
--- a/Bubblia/Bubblia/HandPose/HandPose.swift
+++ b/Bubblia/Bubblia/HandPose/HandPose.swift
@@ -43,8 +43,8 @@ struct HandPose {
     }
     
     func drawWireframeToContext(_ context: CGContext,
-                                applying transform: CGAffineTransform? = nil, point: CGPoint, pastStatus: HandStatus) -> HandStatus {
-        var returnValue: HandStatus = HandStatus.possible
+                                applying transform: CGAffineTransform? = nil, point: CGPoint, pastStatus: HandPoseStatus) -> HandPoseStatus {
+        var returnValue: HandPoseStatus = HandPoseStatus.possible
         
         let scale = drawingScale
 

--- a/Bubblia/Bubblia/HandPose/HandPose.swift
+++ b/Bubblia/Bubblia/HandPose/HandPose.swift
@@ -43,7 +43,7 @@ struct HandPose {
     }
     
     func drawWireframeToContext(_ context: CGContext,
-                                applying transform: CGAffineTransform? = nil, point: CGPoint) -> HandStatus {
+                                applying transform: CGAffineTransform? = nil, point: CGPoint, pastStatus: HandStatus) -> HandStatus {
         var returnValue: HandStatus = HandStatus.possible
         
         let scale = drawingScale
@@ -52,6 +52,7 @@ struct HandPose {
             let thumbPoint = landmarks[0].location
             let middlePoint = landmarks[1].location
             let distance = CGPointDistance(from: thumbPoint, to: middlePoint)
+            
             
             let thumbMiddleCenterPoint = CGPoint.midPoint(p1: thumbPoint, p2: middlePoint)
 
@@ -66,20 +67,18 @@ struct HandPose {
                 ViewController.counter += 1
                 context.setFillColor(UIColor.green.cgColor)
                 context.setStrokeColor(UIColor.green.cgColor)
-                if centerLayerPoint.distance(from: point) < 50
+                if centerLayerPoint.distance(from: point) < 45 && pastStatus == .possible
                 {
                     returnValue = .pinched
                 } else {
                     returnValue = .invalid
                 }
-            } else if distance < 0.08 {
-                context.setFillColor(UIColor.yellow.cgColor)
-                context.setStrokeColor(UIColor.yellow.cgColor)
-                returnValue = .possible
             } else {
                 context.setFillColor(UIColor.red.cgColor)
                 context.setStrokeColor(UIColor.red.cgColor)
-                returnValue = .possible
+                if distance > 0.15 {
+                    returnValue = .possible
+                }
             }
         }
         // Draw the landmarks on top of the lines' endpoints.

--- a/Bubblia/Bubblia/HandPose/HandPoseStatus.swift
+++ b/Bubblia/Bubblia/HandPose/HandPoseStatus.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum HandStatus: Int, CaseIterable {
+enum HandPoseStatus: Int, CaseIterable {
     case possible
     case pinched
     case invalid

--- a/Bubblia/Bubblia/ViewController.swift
+++ b/Bubblia/Bubblia/ViewController.swift
@@ -274,8 +274,9 @@ class ViewController: UIViewController {
         CATransaction.setCompletionBlock({
             // https://stackoverflow.com/questions/20244933/get-current-caanimation-transform-value
             let currentOpacity = self.layer.presentation()?.value(forKeyPath: "opacity") ?? 0.0
-            if (currentOpacity as! Double) <= 0.01 {
+            if (currentOpacity as! Double) <= 0.001 {
                 print("-----GAME OVER-----")
+                self.gameOver = true
                 self.layer.isHidden = true
                 
                 self.labelOpacityAnimation(target: self.gameOverLabel, duration: 0.25, targetOpacity: 1, completion: { _ in
@@ -289,7 +290,6 @@ class ViewController: UIViewController {
                     }
                     
                     self.drawPath.removeAllPoints()
-                    self.gameOver = true
                     DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
                         self.gameCanRestart = true
                     })

--- a/Bubblia/Bubblia/ViewController.swift
+++ b/Bubblia/Bubblia/ViewController.swift
@@ -36,6 +36,7 @@ class ViewController: UIViewController {
     
     private var gameStart = false
     private var gameOver = false
+    private var gameCanRestart = false
     
     private var highScore: Int = 0
     
@@ -288,8 +289,9 @@ class ViewController: UIViewController {
                     }
                     
                     self.drawPath.removeAllPoints()
+                    self.gameOver = true
                     DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
-                        self.gameOver = true
+                        self.gameCanRestart = true
                     })
                 })
             } else {
@@ -404,6 +406,7 @@ class ViewController: UIViewController {
         
         layer.isHidden = false
         gameOver = false
+        gameCanRestart = false
     }
     
 }
@@ -460,7 +463,7 @@ extension ViewController {
                             }
                     }
                 case .invalid:
-                    if gameOver == true && pastHandStatus == .possible {
+                    if gameCanRestart == true && pastHandStatus == .possible {
                         DispatchQueue.main.async {
                             
                             self.gameRestart()

--- a/Bubblia/Bubblia/ViewController.swift
+++ b/Bubblia/Bubblia/ViewController.swift
@@ -73,7 +73,7 @@ class ViewController: UIViewController {
 
     var videoProcessingChain: VideoProcessingChain!
     
-    private var pastHandStatus: HandStatus = .possible
+    private var pastHandStatus: HandPoseStatus = .possible
     
     override func viewDidLoad() {
         

--- a/Bubblia/Bubblia/ViewController.swift
+++ b/Bubblia/Bubblia/ViewController.swift
@@ -449,7 +449,7 @@ extension ViewController {
             let drawPathMiddlePoint = CGPoint(x: drawPath.bounds.midX, y: drawPath.bounds.midY)
             
             for pose in poses {
-                let handStatus = pose.drawWireframeToContext(cgContext, applying: pointTransform, point: drawPathMiddlePoint)
+                let handStatus = pose.drawWireframeToContext(cgContext, applying: pointTransform, point: drawPathMiddlePoint, pastStatus: pastHandStatus)
                 switch handStatus {
                 case .possible:
                     break


### PR DESCRIPTION
### 세부 사항

- 463cfbc74ec1351b709fc85834371cecf6a2a019 : 플레이어가 점수를 획득할 수 있는 '범위값' 조정하기
- 463cfbc74ec1351b709fc85834371cecf6a2a019 : 플레이어가 점수를 획득할 수 있는 'HandStatus Case' 조정하기
- 0c306a7198d599b9fe4ca6d5b5dccf14c6162f0c : 플레이어가 점수를 획득할 수 있는 노란 열매의 'Opacity값' 조정하기
- 117ad7871c03e80ac65f05fa82bf1dcf05456d04 : 플레이어의 점수가 더해지는 '시점' 조정하기 (게임 오버 직후에는 점수가 변경될 수 없게 만들기)

### ABOUT 117ad7871c03e80ac65f05fa82bf1dcf05456d04 :플레이어의 점수가 더해지는 '시점' 조정

**기존의 ViewController.swift 게임 오버 시,**
```
DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
                        self.gameOver = true
                    })
```
**게임 재시작 메소드 호출**
```
if gameCanRestart == true && pastHandStatus == .possible {
```

- 제한 시간 내에 열매를 없애지 못한 경우, 1초 후 gameOver = true로 변경
-> 게임 재시작 시점을 플레이어가 자신의 상태를 인식한 후 플레이가 가능하도록 만들기 위해 이러한 처리를 했었음
-> **게임 오버** 시점과 **게임 재시작 가능 시점**이 분리되어야할 필요성을 느껴, 이 둘을 분리하기 위해 변수 하나를 추가함 : gameCanRestart

---
개선된 **ViewController.swift** 게임 오버 시,
```
 self.gameOver = true
                    DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
                        self.gameCanRestart = true
                    })
```
- 게임 오버 시점은 열매를 없애지 못한 그 시점에 바로 gameOver = true로 전환
- 이로부터 1초 후, 게임 재시작이 가능하도록 gameCanRestart = true로 전환
- 이로 인해 게임 재시작 관련 메소드 호출도 gameOver == true가 아닌, gameCanRestart == true로 변경됨
```
if gameCanRestart == true && pastHandStatus == .possible {
```

close #5 