### PR TITLE
[FIX] Background Handling (#15)

### DIFF
--- a/Bubblia/Bubblia/ViewController.swift
+++ b/Bubblia/Bubblia/ViewController.swift
@@ -197,8 +197,9 @@ class ViewController: UIViewController {
         drawParticle(centerPoint: CGPoint(x: width/2, y: height/2))
         particleLayer.fillColor = UIColor.accentColor?.cgColor
         particleLayer.opacity = 0
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(gameIsOver), name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
-    
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
@@ -206,10 +207,16 @@ class ViewController: UIViewController {
     }
     
     override func viewWillDisappear(_ animated: Bool) {
-//        cameraFeedSession?.stopRunning()
         super.viewWillDisappear(animated)
     }
-        
+     
+    @objc func gameIsOver() {
+        if gameStart == true {
+            gameOver = true
+            setUIGameOver()
+        }
+    }
+    
     func alert(title: String, message: String, actions: [UIAlertAction]) {
             let alertController = UIAlertController(title: title,
                                                     message: message,
@@ -272,25 +279,7 @@ class ViewController: UIViewController {
             // https://stackoverflow.com/questions/20244933/get-current-caanimation-transform-value
             let currentOpacity = self.layer.presentation()?.value(forKeyPath: "opacity") ?? 0.0
             if (currentOpacity as! Double) <= 0.001 {
-                print("-----GAME OVER-----")
-                self.gameOver = true
-                self.layer.isHidden = true
-                
-                self.labelOpacityAnimation(target: self.gameOverLabel, duration: 0.25, targetOpacity: 1, completion: { _ in
-                    
-                    print(self.highScore)
-                    print(self.scoreInt)
-                    if self.highScore < self.scoreInt {
-                        self.labelOpacityAnimation(target: self.highScoreNoticeLabel, duration: 0.25, targetOpacity: 1, completion: { _ in
-                            self.checkHighScore()
-                        })
-                    }
-                    
-                    self.drawPath.removeAllPoints()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
-                        self.gameCanRestart = true
-                    })
-                })
+                self.setUIGameOver()
             } else {
                 print(">>> GOGOGO!!! <<<")
             }
@@ -305,6 +294,28 @@ class ViewController: UIViewController {
         layer.add(animation, forKey: "changeOpacity")
         
         CATransaction.commit()
+    }
+    
+    func setUIGameOver() {
+        print("-----GAME OVER-----")
+        gameOver = true
+        layer.isHidden = true
+        
+        labelOpacityAnimation(target: gameOverLabel, duration: 0.25, targetOpacity: 1, completion: { _ in
+            
+            print(self.highScore)
+            print(self.scoreInt)
+            if self.highScore < self.scoreInt {
+                self.labelOpacityAnimation(target: self.highScoreNoticeLabel, duration: 0.25, targetOpacity: 1, completion: { _ in
+                    self.checkHighScore()
+                })
+            }
+            
+            self.drawPath.removeAllPoints()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
+                self.gameCanRestart = true
+            })
+        })
     }
     
     func addParticleFadeInOutAnimation() {


### PR DESCRIPTION
### 변경 및 추가 사항
**방법3: Background로 이탈 시, 게임 오버 구현 완료**
**ViewController.swift**
1. 기존의 노란 열매의 Opacity를 조절하는 func addOpacityChangeAnimation 내부, gameOver에 해당하는 부분을 func setUIGameOver로 분리
```
func setUIGameOver() {
        print("-----GAME OVER-----")
        gameOver = true
        layer.isHidden = true
        
        labelOpacityAnimation(target: gameOverLabel, duration: 0.25, targetOpacity: 1, completion: { _ in
            
            print(self.highScore)
            print(self.scoreInt)
            if self.highScore < self.scoreInt {
                self.labelOpacityAnimation(target: self.highScoreNoticeLabel, duration: 0.25, targetOpacity: 1, completion: { _ in
                    self.checkHighScore()
                })
            }
            
            self.drawPath.removeAllPoints()
            DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
                self.gameCanRestart = true
            })
        })
    }
```
2. Background 상태로 전환 시 호출할 objc func 작성
- 단, 게임이 시작된 경우에만 Background전환 시 GameOver 상태로 만들도록 함
```
@objc func gameIsOver() {
        if gameStart == true {
            gameOver = true
            setUIGameOver()
        }
    }
```
3. Application이 Background 상태로 전환되었는지에 대한 체크를 위해 NotificationCenter.addObserver를 추가
```
NotificationCenter.default.addObserver(self, selector: #selector(gameIsOver), name: UIApplication.didEnterBackgroundNotification, object: nil)
```

Close #15 