### PR TITLE
[FEAT] Insert BGM & SFX Manager (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.mp3
+
 .DS_Store
 # Xcode
 #

--- a/Bubblia/Bubblia.xcodeproj/project.pbxproj
+++ b/Bubblia/Bubblia.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		3A4A54D428BC902C00FFE870 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3A4A54D228BC902C00FFE870 /* LaunchScreen.storyboard */; };
 		3A4A54E028BD031C00FFE870 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4A54DF28BD031C00FFE870 /* Constants.swift */; };
 		3A4A54E228BD312300FFE870 /* UserDefaultSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4A54E128BD312300FFE870 /* UserDefaultSetting.swift */; };
+		3A7104B728D0AFF500D84C9F /* UGAUGA_AGUAGUBGM.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 3A7104B528D0AFF500D84C9F /* UGAUGA_AGUAGUBGM.mp3 */; };
+		3A7104B828D0AFF500D84C9F /* AGUAGU_AGUAGUSFX.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 3A7104B628D0AFF500D84C9F /* AGUAGU_AGUAGUSFX.mp3 */; };
 		3A7CC72A28BF28FF00FBD13E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3A7CC72C28BF28FF00FBD13E /* Localizable.strings */; };
 		3A7CC73128BF2BB100FBD13E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3A7CC73328BF2BB100FBD13E /* InfoPlist.strings */; };
 		3A7CC7A328CA23D200FBD13E /* CGPoint+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7CC7A228CA23D200FBD13E /* CGPoint+.swift */; };
@@ -43,6 +45,8 @@
 		3A4A54D528BC902C00FFE870 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3A4A54DF28BD031C00FFE870 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		3A4A54E128BD312300FFE870 /* UserDefaultSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultSetting.swift; sourceTree = "<group>"; };
+		3A7104B528D0AFF500D84C9F /* UGAUGA_AGUAGUBGM.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = UGAUGA_AGUAGUBGM.mp3; sourceTree = "<group>"; };
+		3A7104B628D0AFF500D84C9F /* AGUAGU_AGUAGUSFX.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = AGUAGU_AGUAGUSFX.mp3; sourceTree = "<group>"; };
 		3A7CC72B28BF28FF00FBD13E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		3A7CC72D28BF2A4F00FBD13E /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		3A7CC72E28BF2A5600FBD13E /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -90,6 +94,7 @@
 		3A4A54C328BC902A00FFE870 /* Bubblia */ = {
 			isa = PBXGroup;
 			children = (
+				3A7104B428D0AFED00D84C9F /* Sounds */,
 				3A7CC7AB28CA2B5A00FBD13E /* Camera */,
 				3A7CC7A628CA28A500FBD13E /* HandPose */,
 				3A4A54C428BC902A00FFE870 /* AppDelegate.swift */,
@@ -106,6 +111,15 @@
 				3A7CC72728BF28B000FBD13E /* Localizing */,
 			);
 			path = Bubblia;
+			sourceTree = "<group>";
+		};
+		3A7104B428D0AFED00D84C9F /* Sounds */ = {
+			isa = PBXGroup;
+			children = (
+				3A7104B628D0AFF500D84C9F /* AGUAGU_AGUAGUSFX.mp3 */,
+				3A7104B528D0AFF500D84C9F /* UGAUGA_AGUAGUBGM.mp3 */,
+			);
+			path = Sounds;
 			sourceTree = "<group>";
 		};
 		3A7CC72728BF28B000FBD13E /* Localizing */ = {
@@ -209,9 +223,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				3A4A54D428BC902C00FFE870 /* LaunchScreen.storyboard in Resources */,
+				3A7104B728D0AFF500D84C9F /* UGAUGA_AGUAGUBGM.mp3 in Resources */,
 				3A4A54D128BC902C00FFE870 /* Assets.xcassets in Resources */,
 				3A4A54CC28BC902A00FFE870 /* Main.storyboard in Resources */,
 				3A7CC72A28BF28FF00FBD13E /* Localizable.strings in Resources */,
+				3A7104B828D0AFF500D84C9F /* AGUAGU_AGUAGUSFX.mp3 in Resources */,
 				3A7CC73128BF2BB100FBD13E /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Bubblia/Bubblia.xcodeproj/project.pbxproj
+++ b/Bubblia/Bubblia.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		3A4A54E228BD312300FFE870 /* UserDefaultSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4A54E128BD312300FFE870 /* UserDefaultSetting.swift */; };
 		3A7104B728D0AFF500D84C9F /* UGAUGA_AGUAGUBGM.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 3A7104B528D0AFF500D84C9F /* UGAUGA_AGUAGUBGM.mp3 */; };
 		3A7104B828D0AFF500D84C9F /* AGUAGU_AGUAGUSFX.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 3A7104B628D0AFF500D84C9F /* AGUAGU_AGUAGUSFX.mp3 */; };
+		3A7104BA28D0B7BE00D84C9F /* SoundManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7104B928D0B7BE00D84C9F /* SoundManager.swift */; };
 		3A7CC72A28BF28FF00FBD13E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3A7CC72C28BF28FF00FBD13E /* Localizable.strings */; };
 		3A7CC73128BF2BB100FBD13E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3A7CC73328BF2BB100FBD13E /* InfoPlist.strings */; };
 		3A7CC7A328CA23D200FBD13E /* CGPoint+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7CC7A228CA23D200FBD13E /* CGPoint+.swift */; };
@@ -47,6 +48,7 @@
 		3A4A54E128BD312300FFE870 /* UserDefaultSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultSetting.swift; sourceTree = "<group>"; };
 		3A7104B528D0AFF500D84C9F /* UGAUGA_AGUAGUBGM.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = UGAUGA_AGUAGUBGM.mp3; sourceTree = "<group>"; };
 		3A7104B628D0AFF500D84C9F /* AGUAGU_AGUAGUSFX.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = AGUAGU_AGUAGUSFX.mp3; sourceTree = "<group>"; };
+		3A7104B928D0B7BE00D84C9F /* SoundManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundManager.swift; sourceTree = "<group>"; };
 		3A7CC72B28BF28FF00FBD13E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		3A7CC72D28BF2A4F00FBD13E /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		3A7CC72E28BF2A5600FBD13E /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -102,6 +104,7 @@
 				3A4A54DF28BD031C00FFE870 /* Constants.swift */,
 				3A4A54C828BC902A00FFE870 /* ViewController.swift */,
 				3A4A54E128BD312300FFE870 /* UserDefaultSetting.swift */,
+				3A7104B928D0B7BE00D84C9F /* SoundManager.swift */,
 				3A7CC7A128CA23A900FBD13E /* Extensions */,
 				3A4A54CA28BC902A00FFE870 /* Main.storyboard */,
 				3A4A54D228BC902C00FFE870 /* LaunchScreen.storyboard */,
@@ -255,6 +258,7 @@
 				3A4A54C728BC902A00FFE870 /* SceneDelegate.swift in Sources */,
 				3A7CC7B528CA31AB00FBD13E /* VideoProcessingChain.swift in Sources */,
 				3A144B3528BDFE78001DB6F0 /* UIColor+.swift in Sources */,
+				3A7104BA28D0B7BE00D84C9F /* SoundManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bubblia/Bubblia/SoundManager.swift
+++ b/Bubblia/Bubblia/SoundManager.swift
@@ -5,7 +5,6 @@
 //  Created by 황정현 on 2022/09/13.
 //
 
-import Foundation
 import AVFoundation
 
 class SoundManager {

--- a/Bubblia/Bubblia/SoundManager.swift
+++ b/Bubblia/Bubblia/SoundManager.swift
@@ -1,0 +1,52 @@
+//
+//  SoundManager.swift
+//  Bubblia
+//
+//  Created by 황정현 on 2022/09/13.
+//
+
+import Foundation
+import AVFoundation
+
+class SoundManager {
+    static var shared = SoundManager()
+    private var bgmPlayer = AVAudioPlayer()
+    private var sfxPlayer = AVAudioPlayer()
+    
+    init() {
+        do {
+            try AVAudioSession.sharedInstance().setActive(true)
+            try AVAudioSession.sharedInstance().setCategory(
+                AVAudioSession.Category.playback,
+                options: AVAudioSession.CategoryOptions.mixWithOthers)
+        } catch let error {
+            print(error)
+        }
+        
+        let bgmSource = NSURL(fileURLWithPath: Bundle.main.path(forResource: "UGAUGA_AGUAGUBGM", ofType: "mp3")!)
+        do {
+            bgmPlayer = try AVAudioPlayer(contentsOf: bgmSource as URL)
+            bgmPlayer.numberOfLoops = -1
+            bgmPlayer.prepareToPlay()
+        } catch {
+            print("BGM CAN'T PLAY")
+        }
+    }
+    
+    func playBGM() {
+        bgmPlayer.play()
+    }
+    
+    func playSFX() {
+        let sfxSource = NSURL(fileURLWithPath: Bundle.main.path(forResource: "AGUAGU_AGUAGUSFX", ofType: "mp3")!)
+        do {
+            sfxPlayer = try AVAudioPlayer(contentsOf: sfxSource as URL)
+            sfxPlayer.volume = 0.6
+            sfxPlayer.numberOfLoops = 1
+            sfxPlayer.prepareToPlay()
+        } catch {
+            print("BGM CAN'T PLAY")
+        }
+        sfxPlayer.play()
+    }
+}

--- a/Bubblia/Bubblia/ViewController.swift
+++ b/Bubblia/Bubblia/ViewController.swift
@@ -202,24 +202,7 @@ class ViewController: UIViewController {
         
         NotificationCenter.default.addObserver(self, selector: #selector(gameIsOver), name: UIApplication.didEnterBackgroundNotification, object: nil)
         
-        do {
-            try AVAudioSession.sharedInstance().setActive(true)
-            try AVAudioSession.sharedInstance().setCategory(
-                AVAudioSession.Category.playback,
-                options: AVAudioSession.CategoryOptions.mixWithOthers)
-        } catch let error {
-            print(error)
-        }
-        
-        let bgmSource = NSURL(fileURLWithPath: Bundle.main.path(forResource: "UGAUGA_AGUAGUBGM", ofType: "mp3")!)
-        do {
-            bgmPlayer = try AVAudioPlayer(contentsOf:bgmSource as URL)
-            bgmPlayer.numberOfLoops = -1
-            bgmPlayer.prepareToPlay()
-            bgmPlayer.play()
-        } catch {
-            print("BGM CAN'T PLAY")
-        }
+        SoundManager.shared.playBGM()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -487,6 +470,7 @@ extension ViewController {
                 case .pinched:
                     if gameOver == false && pastHandStatus == .possible {
                         DispatchQueue.main.async {
+                            SoundManager.shared.playSFX()
                                 self.gameStatusUpdateFunction(middlePoint: drawPathMiddlePoint)
                             }
                     }

--- a/Bubblia/Bubblia/ViewController.swift
+++ b/Bubblia/Bubblia/ViewController.swift
@@ -68,6 +68,8 @@ class ViewController: UIViewController {
     
     private var pastHandStatus: HandPoseStatus = .possible
     
+    private var bgmPlayer = AVAudioPlayer()
+    
     override var prefersStatusBarHidden: Bool {
         return true
     }
@@ -199,6 +201,25 @@ class ViewController: UIViewController {
         particleLayer.opacity = 0
         
         NotificationCenter.default.addObserver(self, selector: #selector(gameIsOver), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        
+        do {
+            try AVAudioSession.sharedInstance().setActive(true)
+            try AVAudioSession.sharedInstance().setCategory(
+                AVAudioSession.Category.playback,
+                options: AVAudioSession.CategoryOptions.mixWithOthers)
+        } catch let error {
+            print(error)
+        }
+        
+        let bgmSource = NSURL(fileURLWithPath: Bundle.main.path(forResource: "UGAUGA_AGUAGUBGM", ofType: "mp3")!)
+        do {
+            bgmPlayer = try AVAudioPlayer(contentsOf:bgmSource as URL)
+            bgmPlayer.numberOfLoops = -1
+            bgmPlayer.prepareToPlay()
+            bgmPlayer.play()
+        } catch {
+            print("BGM CAN'T PLAY")
+        }
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -416,7 +437,6 @@ class ViewController: UIViewController {
         gameOver = false
         gameCanRestart = false
     }
-    
 }
 
 extension ViewController: VideoCaptureDelegate {


### PR DESCRIPTION
@Juhwa-Lee1023
@commitcomplete
@LeeSungNo-ian

## 세부 사항 요약
1. BGM, SFX 추가
2. BGM 및 SFX Player 작성

## SEQUENCE: BGM SIDE
**1차 시도**
- BGM은 AVFoundation의 AVPlayer를 사용해 viewDidLoad에서 1회성 호출을 하는 형태로 작성
-> cb05d3f42c65b59a6d893a20fc5404d76e43fcf0
**2차 시도**
- BGM과 SFX 둘 다 하나의 클래스로 묶어 관리하고자 Class로 만듦
-> 916542d27ed2af4ee4307294e5c38237c0817b0a

## SEQUENCE: SFX SIDE
**1. AVPlayerSession 설정**
- BGM과 동시에 사운드가 플레이되어야하기 때문에 AVPlayerSession을 여러 사운드가 플레이될 수 있도록 변경
```
do {
            try AVAudioSession.sharedInstance().setActive(true)
            try AVAudioSession.sharedInstance().setCategory(
                AVAudioSession.Category.playback,
                options: AVAudioSession.CategoryOptions.mixWithOthers)
        } catch let error {
            print(error)
        }
```
**2. SFX AVSoundPlayer 추가_첫번째 -> 실패**
- 클래스 내부에서 bgm과 동일하게 class init 시 sfx url 호출을 1회성으로 들고오도록 함
- sfx가 중첩되어 여러 번 반복되어야할 때, sfx 사운드가 재생이 완료된 시점이 아니면 sfx가 다시 호출되지 않는 문제점이 발생

**3. SystemSound로 처리 -> 실패**
- 짧은 사운드라서 AudioServicesPlaySystemSound를 통해 즉각적으로 울릴 수 있는 형태로 만들었지만, BGM이 있는 상태에서는 SystemSound가 작게 처리되어 원하는 결과물을 얻지 못함

**4. SFX AVSoundPlayer 추가_두번째 -> 성공**
- '2'에서 수행한 방식과 동일하나, sfx url 호출을 1회성이 아닌, playSFX 메소드가 호출될 때마다 갱신하는 형태로 변경
- SFX를 여러 번 플레이해야하는 경우에도 정상적으로 동작하는 것을 확인

## 추후 방향성
- UT를 통해 BGM & SFX 유효성 검사
- 무드에 맞는 BGM & SFX 재작성

Close #19 